### PR TITLE
Add psr dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
   "require": {
     "php": "^8.0",
     "ecotone/ecotone": "~1.32.1",
+    "psr/log": "^1.0|^2.0|^3.0",
     "laravel/framework": "^9.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
   },
   "require": {
     "php": "^8.0",
+    "psr/log": "^1.0|^2.0|^3.0",
     "ecotone/ecotone": "~1.32.0",
     "laravel/framework": "^9.0"
   },

--- a/src/CombinedLogger.php
+++ b/src/CombinedLogger.php
@@ -7,14 +7,9 @@ use Psr\Log\LoggerInterface;
 
 class CombinedLogger extends AbstractLogger implements LoggerInterface
 {
-    /**
-     * @var LoggerInterface
-     */
-    private $applicationLogger;
-    /**
-     * @var LoggerInterface
-     */
-    private $consoleLogger;
+    private LoggerInterface $applicationLogger;
+
+    private LoggerInterface $consoleLogger;
 
     public function __construct(LoggerInterface $applicationLogger, LoggerInterface $consoleLogger)
     {
@@ -22,7 +17,7 @@ class CombinedLogger extends AbstractLogger implements LoggerInterface
         $this->consoleLogger = $consoleLogger;
     }
 
-    public function log($level, $message, array $context = array())
+    public function log($level, $message, array $context = array()): void
     {
         $this->applicationLogger->log($level, $message, $context);
         $this->consoleLogger->log($level, $message, $context);


### PR DESCRIPTION
This PR solves a problem with the logger implementation not being compatible with PSR-3. This was not discovered previously because PSR-3 was not a dependency of the package.